### PR TITLE
Consistently resolve `bump` in call site context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * You can now prefix constructor arguments with an explicit visibility (`priv`, `pub`, `pub(restriction)`) to capture them as component instance fields.
 
+* `bump` resolution is now more reliable in cases where the macro input is constructed in multiple macro contexts.
+
 ## 0.0.2
 
 2020-10-08

--- a/proc-macro-definitions/src/component_declaration/mod.rs
+++ b/proc-macro-definitions/src/component_declaration/mod.rs
@@ -753,7 +753,7 @@ impl ComponentDeclaration {
 
 		let render_args = {
 			let implied_bump = if imply_bump {
-				quote_spanned! {render_paren.span=>
+				quote_spanned! {render_paren.span.resolved_at(Span::call_site())=>
 					bump: &'bump #asteracea::lignin_schema::lignin::bumpalo::Bump,
 				}
 			} else {
@@ -773,7 +773,7 @@ impl ComponentDeclaration {
 
 		let render_type = match render_type {
 			ReturnType::Default if imply_bump => {
-				let bump = Lifetime::new("'bump", render_paren.span);
+				let bump = Lifetime::new("'bump", render_paren.span.resolved_at(Span::call_site()));
 				parse_quote!(-> #asteracea::lignin_schema::lignin::Node<#bump>)
 			}
 			render_type => render_type,

--- a/proc-macro-definitions/src/lib.rs
+++ b/proc-macro-definitions/src/lib.rs
@@ -71,7 +71,7 @@ impl ToTokens for BumpFormat {
 			bump_span,
 			input,
 		} = self;
-		let bump = Ident::new("bump", *bump_span);
+		let bump = Ident::new("bump", bump_span.resolved_at(Span::call_site()));
 		output.extend(quote! {
 			#asteracea::lignin_schema::lignin::Node::Text(
 				#asteracea::lignin_schema::lignin::bumpalo::format!(in #bump, #input)

--- a/proc-macro-definitions/src/part/html_definition.rs
+++ b/proc-macro-definitions/src/part/html_definition.rs
@@ -131,7 +131,7 @@ impl<C> HtmlDefinition<C> {
 
 		let asteracea = asteracea_ident(name.span());
 
-		let bump = Ident::new("bump", name.span());
+		let bump = Ident::new("bump", lt.span().resolved_at(Span::call_site()));
 
 		let cx = GenerateContext {
 			scope_definitions: if !scope_definitions.is_empty() {

--- a/proc-macro-definitions/src/part/mod.rs
+++ b/proc-macro-definitions/src/part/mod.rs
@@ -21,7 +21,7 @@ use syn::{
 	braced, bracketed,
 	parse::{Parse, ParseStream, Result},
 	token::{Add, Brace, Bracket},
-	Error, LitStr, Token,
+	Error, Ident, LitStr, Token,
 };
 
 pub struct Part<C> {
@@ -180,8 +180,9 @@ impl<C> PartBody<C> {
 					.iter()
 					.map(|part| part.part_tokens(cx))
 					.collect::<coreResult<Vec<_>, _>>()?;
+				let bump = Ident::new("bump", bracket.span.resolved_at(Span::call_site()));
 				quote_spanned! {bracket.span=>
-					#asteracea::lignin_schema::lignin::Node::Multi(&*bump.alloc_with(|| [
+					#asteracea::lignin_schema::lignin::Node::Multi(&*#bump.alloc_with(|| [
 						#(#m,)*
 					]))
 				}

--- a/tests/macro_rules_quoting.rs
+++ b/tests/macro_rules_quoting.rs
@@ -1,0 +1,19 @@
+use asteracea::component;
+
+macro_rules! just_plain {
+	($name:ident => $($contents:tt)*) => {
+		component! {
+			$name()()
+			$($contents)*
+		}
+	}
+}
+
+macro_rules! nested {
+	($name:ident => $($contents:tt)*) => {
+		just_plain!($name => $($contents)*);
+	}
+}
+
+just_plain!(JustPlain => <br>);
+nested!(Nested => <br>);

--- a/tests/macro_rules_quoting.rs
+++ b/tests/macro_rules_quoting.rs
@@ -11,7 +11,7 @@ macro_rules! just_plain {
 
 macro_rules! nested {
 	($name:ident => $($contents:tt)*) => {
-		just_plain!($name => $($contents)*);
+		just_plain!($name => <div $($contents)*>);
 	}
 }
 


### PR DESCRIPTION
Consistently resolve bump in call site context, in case the `component!` invocation is constructed over multiple contexts.

This also tests and as such closes #9.