### PR TITLE
Return Node<'static> by default from .render() instead of ()

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,11 @@ assert!(matches!(
 
 ### Unit component
 
-If the component body isn't a `Node` expression, the component will return `()` by default and won't require a `Bump` reference to be rendered.
-
-A different return type can be specified after the render argument list.
+A return type other than `Node` can be specified after the render argument list, and components that don't output potentially dynamic `Node`s won't require a `Bump` reference to render:
 
 ```rust
 asteracea::component! {
-  Unit(/* ::new arguments */)(/* .render arguments */) /* -> () */
+  Unit(/* ::new arguments */)(/* .render arguments */) -> ()
   {} // Empty Rust block
 }
 

--- a/proc-macro-definitions/src/component_declaration/mod.rs
+++ b/proc-macro-definitions/src/component_declaration/mod.rs
@@ -776,6 +776,9 @@ impl ComponentDeclaration {
 				let bump = Lifetime::new("'bump", render_paren.span.resolved_at(Span::call_site()));
 				parse_quote!(-> #asteracea::lignin_schema::lignin::Node<#bump>)
 			}
+			ReturnType::Default if !imply_bump => {
+				parse_quote!(-> #asteracea::lignin_schema::lignin::Node<'static>)
+			}
 			render_type => render_type,
 		};
 

--- a/tests/templates.rs
+++ b/tests/templates.rs
@@ -163,8 +163,8 @@ component! {
 
 //TODO: This should show a warning for an unused struct. Reasearch why that doesn't happen.
 component! {
-	Unused()() // The render return type defaults to () if bump isn't implicit.
-	{}
+	Unused()() // The render return type defaults to Node<'static> if bump isn't implicit.
+	""
 }
 
 #[test]


### PR DESCRIPTION
Returning `()` is probably the rarer case.