### PR TITLE
Better `Unpin` constraints via `impl` collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ TODO: Date
   * `with { …; } <…>` expressions to insert statements into the `.render` method
   * Conditional content via `if {…} <…>`, `if …… else <…>` and `match <…> [ … ]`
   * Box expressions: `box ⟦priv …⟦: ⟦struct⟧ … ⟦where …;⟧⟧⟧ <…>`
+  * More accurate `Unpin` constraints on generated storage context types
 
 * Revisions:
   * Improved `Counter` example in the README.

--- a/proc-macro-definitions/src/parse_with_context.rs
+++ b/proc-macro-definitions/src/parse_with_context.rs
@@ -153,6 +153,7 @@ impl StorageContext {
 		};
 
 		let mut phantom_pinned = None;
+		let mut strict_unpin_constraint = None;
 		let structural_pinning = self
 			.field_definitions
 			.iter()
@@ -168,32 +169,33 @@ impl StorageContext {
 						initial_value: _,
 						structurally_pinned: _,
 					} = field;
-					let pinned_name = Ident::new(&format!("{}_pinned", field_name), field_name.span());
+					let pinned_name =
+						Ident::new(&format!("{}_pinned", field_name), field_name.span());
 
-					let not_unpin_assertion = if type_name.to_string().contains("__Asteracea__") {
+					if type_name.to_string().contains("__Asteracea__") {
 						// Asteracea itself won't implement Unpin, so we're in the clear here.
-						None
-					} else if generics.params.is_empty() {
-						// It's already possible to assert this correctly on the outer type, but we can't check for the field type,
-						// so we have to force `!Unpin` on the storage context even if it wouldn't be necessary otherwise.
-						phantom_pinned.get_or_insert_with(||{quote_spanned! {field_name.span().resolved_at(Span::mixed_site())=>
-							__Asteracea__pinned: ::std::marker::PhantomPinned,
-						}});
-						Some(quote_spanned! {
-							type_name.span()=> ::#asteracea::static_assertions::assert_not_impl_any!(#type_name: Unpin);
-						})
 					} else {
-						// Any other case won't be provably sound until min_specialization lands.
-						Some(quote_spanned! {generics.span()=>
-							::std::compile_error!("Asteracea can't soundly generate named generic storage context types if anything inside requires pinning :( (Once min_specialization lands, the required static assert against `Self: Unpin` will become available. For now, please use a `box <…>`-expression with either anonymous or manually defined storage context type to pin any child components in a heap allocation.)");
-						})
+						// It's already possible to assert this correctly on the outer type, but we can't (nicely) check in relation to the field type
+						// without <https://doc.rust-lang.org/stable/unstable-book/language-features/min-specialization.html>,
+						// so we have to force `!Unpin` on the storage context even if it wouldn't be necessary otherwise.
+						phantom_pinned.get_or_insert_with(|| {
+							quote_spanned! {field_name.span().resolved_at(Span::mixed_site())=>
+								__Asteracea__pinned: ::std::marker::PhantomPinned,
+							}
+						});
+						strict_unpin_constraint.get_or_insert_with(|| {
+							quote_spanned! {type_name.span()=>
+								/// Forbids [`Unpin`](`::std::marker::Unpin`) on this generated storage context type.
+								///
+								/// See [`StrictUnpinConstraint`](`::asteracea::StrictUnpinConstraint`) for more information.
+								impl#impl_generics ::#asteracea::StrictUnpinConstraint for #type_name#type_generics #where_clause {}
+							}
+						});
 					};
 
 					Some(quote_spanned! {field_name.span()=>
 						#(#attributes)*
 						#visibility fn #pinned_name(self: ::std::pin::Pin<&Self>) -> ::std::pin::Pin<&#field_type> {
-							#not_unpin_assertion
-
 							unsafe {
 								// SAFETY:
 								//   That the storage type doesn't implement `Unpin` is asserted above, #[repr] is blocked explicitly and
@@ -235,6 +237,8 @@ impl StorageContext {
 			#explicit_default_drop
 
 			#structural_pinning
+
+			#strict_unpin_constraint
 		})
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,3 +52,13 @@ pub fn unsound_extend_reference<T: ?Sized>(reference: &T) -> &'static T {
 		::std::mem::transmute(reference)
 	}
 }
+
+/// Until [`min_specialization`](https://doc.rust-lang.org/stable/unstable-book/language-features/min-specialization.html)
+/// lands, this trait is used to ensure no unsound [`Unpin`](`::std::marker::Unpin`) implementations exist on generated storage contexts that
+/// have an automatically generated structural pinning implementation.
+pub trait StrictUnpinConstraint {}
+
+/// If this `impl` collides, then `T` erroneously implements [`Unpin`](::std::marker::Unpin`).
+///
+/// See [`StrictUnpinConstraint`] for more information.
+impl<T: Unpin> StrictUnpinConstraint for T {}


### PR DESCRIPTION
If trait overlap detection was more accurate, it would be possible to forbid unsound [`Unpin`](https://doc.rust-lang.org/stable/std/marker/trait.Unpin.html) implementations much more ergonomically (showing a very descriptive trait name with associated documentation in the error). However, this is currently blocked by https://github.com/rust-lang/rust/issues/50551 `Coherence rules are not consistent when applied to auto traits` [![issue status](https://img.shields.io/github/issues/detail/state/rust-lang/rust/50551?label=%20&logo=github)](https://github.com/rust-lang/rust/issues/50551).

Alternatively, this pull request could be made obsolete using `const` asserts based on `min_specialization`, via https://github.com/rust-lang/rust/issues/31844 "Tracking issue for specialization (RFC 1210)" [![issue status](https://img.shields.io/github/issues/detail/state/rust-lang/rust/31844?label=%20&logo=github)](https://github.com/rust-lang/rust/issues/31844).