### PR TITLE
Use $crate instead of proc-macro-crate

### DIFF
--- a/proc-macro-definitions/Cargo.toml
+++ b/proc-macro-definitions/Cargo.toml
@@ -31,9 +31,7 @@ backtrace = [] # Enables additional error traces, at the cost of code size and p
 call2-for-syn = "2.0.3"
 debugless-unwrap = "0.0.4"
 heck = "0.3.1"
-lazy_static = "1.4.0"
 quote = "1.0.2"
-proc-macro-crate = "0.1.4"
 proc-macro2 = "1.0.7"
 syn-mid = { version = "0.5.0", features = ["clone-impls"] }
 take_mut = "0.2.2"

--- a/proc-macro-definitions/src/component_declaration/mod.rs
+++ b/proc-macro-definitions/src/component_declaration/mod.rs
@@ -3,8 +3,9 @@ use self::{
 	parameter_helper_definitions::{CustomArgument, ParameterHelperDefintions},
 };
 use crate::{
-	asteracea_ident,
+	asteracea_crate,
 	part::GenerateContext,
+	set_asteracea_crate,
 	storage_configuration::StorageTypeConfiguration,
 	storage_context::{ParseContext, ParseWithContext, StorageContext},
 	syn_ext::{AddOptionExt, *},
@@ -72,6 +73,9 @@ impl Configuration for ComponentRenderConfiguration {
 
 impl Parse for ComponentDeclaration {
 	fn parse(input: ParseStream<'_>) -> Result<Self> {
+		set_asteracea_crate(input.parse()?);
+		input.parse::<Token![,]>()?;
+
 		let attributes = input.call(Attribute::parse_outer)?;
 		let visibility = input.parse()?;
 
@@ -195,18 +199,18 @@ impl Parse for ComponentDeclaration {
 
 				let semi = Token![;](extracted_question.span);
 
-				let asteracea = asteracea_ident(extracted_for.span);
+				let asteracea = asteracea_crate();
 
 				//TODO: Is there a way to write this span more nicely?
 				let ref_statement_span = quote!(#ref_token #extracted_for #scope #extracted_name #extracted_colon #extracted_type).span();
 				let call_site_node =
-					Ident::new("node", ref_statement_span.resolved_at(Span::call_site()));
+					Ident::new("node", ref_statement_span.resolved_at(ref_token.span));
 				rhizome_extractions.push({
 					quote_spanned! {
 						ref_statement_span=>
 						#extracted_let #extracted_name#extracted_colon std::sync::Arc<#extracted_type>
 						= <#extracted_type>::extract_from(&#call_site_node)
-							.map_err(|error| ::#asteracea::error::Escalate2::escalate(::std::format!("Dependency resolution error in component {}: {}", ::std::stringify!(#component_name), error)))#extracted_question#semi
+							.map_err(|error| #asteracea::error::Escalate2::escalate(::std::format!("Dependency resolution error in component {}: {}", ::std::stringify!(#component_name), error)))#extracted_question#semi
 					}
 				})
 			} else {
@@ -316,7 +320,7 @@ impl ComponentDeclaration {
 			assorted_items: random_items,
 		} = self;
 
-		let asteracea = asteracea_ident(Span::call_site());
+		let asteracea = asteracea_crate();
 
 		let struct_definition = StorageTypeConfiguration::new_component_root(
 			component_name.clone(),
@@ -336,9 +340,7 @@ impl ComponentDeclaration {
 			false,
 		);
 
-		let bump = quote_spanned! (render_paren.span.resolved_at(Span::call_site())=>
-			bump
-		);
+		let bump = Ident::new("bump", render_paren.span);
 
 		let body = body.part_tokens(&GenerateContext::default())?;
 
@@ -447,13 +449,13 @@ impl ComponentDeclaration {
 
 		let render_type: ReturnType = match &render_type {
 			ReturnType::Default => parse2(quote_spanned! {render_type.span()=>
-				-> ::std::result::Result<::#asteracea::lignin::Node<'bump>, ::#asteracea::error::Escalation>
+				-> ::std::result::Result<#asteracea::lignin::Node<'bump>, #asteracea::error::Escalation>
 			})
 			.unwrap(),
 			ReturnType::Type(arrow, type_) => ReturnType::Type(
 				*arrow,
 				Box::new(Type::Verbatim(
-					quote_spanned!(arrow.span()=> ::std::result::Result<#type_, ::#asteracea::error::Escalation>),
+					quote_spanned!(arrow.span()=> ::std::result::Result<#type_, #asteracea::error::Escalation>),
 				)),
 			),
 		};
@@ -461,7 +463,7 @@ impl ComponentDeclaration {
 		let constructor_block_statements =
 			constructor_block.map(|(_new, _with, block)| block.stmts);
 
-		let call_site_node = Ident::new("node", Span::call_site());
+		let call_site_node = Ident::new("node", constructor_paren.span);
 
 		let (component_impl_generics, component_type_generics, component_where_clause) =
 			component_generics.split_for_impl();
@@ -480,7 +482,7 @@ impl ComponentDeclaration {
 			#(#struct_definition)*
 
 			impl#component_impl_generics #component_name#component_type_generics #component_where_clause {
-				#[::#asteracea::trace_escalations(#component_name)]
+				#[#asteracea::trace_escalations(#asteracea, #component_name)]
 				#(#constructor_attributes)*
 				pub fn new#new_generics(
 					parent_node: &::std::sync::Arc<#asteracea::rhizome::Node>,
@@ -488,7 +490,7 @@ impl ComponentDeclaration {
 						#(#constructor_args_field_patterns,)*
 						__Asteracea__phantom: _,
 					}: #new_args_name#new_args_generic_args,
-				) -> ::std::result::Result<Self, ::#asteracea::error::Escalation> where Self: 'a + 'static { // TODO: Self: 'static is necessary because of `derive_for::<Self>`, but that's not really a good approach... Using derived IDs would be better.
+				) -> ::std::result::Result<Self, #asteracea::error::Escalation> where Self: 'a + 'static { // TODO: Self: 'static is necessary because of `derive_for::<Self>`, but that's not really a good approach... Using derived IDs would be better.
 					let #call_site_node = #asteracea::rhizome::extensions::TypeTaggedNodeArc::derive_for::<Self>(parent_node);
 					#(#rhizome_extractions)*
 					let mut #call_site_node = #call_site_node;
@@ -505,6 +507,7 @@ impl ComponentDeclaration {
 					// data structure as needed.
 					// I really should add benchmarks before trying this, though.
 					let #call_site_node = #call_site_node.into_arc();
+					let _ = &#call_site_node; // Suppress unused variable warning.
 
 					::std::result::Result::Ok(#constructed_value)
 				}
@@ -514,7 +517,7 @@ impl ComponentDeclaration {
 					#new_args_name::builder()
 				}
 
-				#[::#asteracea::trace_escalations(#component_name)]
+				#[#asteracea::trace_escalations(#asteracea, #component_name)]
 				#(#render_attributes)*
 				pub fn render#render_generics(
 					#render_self: ::std::pin::Pin<&'a Self>,

--- a/proc-macro-definitions/src/part/bump_format_shorthand.rs
+++ b/proc-macro-definitions/src/part/bump_format_shorthand.rs
@@ -1,5 +1,5 @@
 use crate::{
-	asteracea_ident,
+	asteracea_crate,
 	storage_context::{ParseContext, ParseWithContext},
 	workaround_module::Configuration,
 };
@@ -28,7 +28,7 @@ pub fn parse_with_context<C: Configuration>(
 	let arg_block: Block = input.parse()?;
 	let formatted_args = arg_block.stmts;
 	let args = quote_spanned!(arg_block.brace_token.span=> {#format_string, #formatted_args});
-	let asteracea = asteracea_ident(bang.span);
+	let asteracea = asteracea_crate();
 	call2_strict(
 		quote_spanned!(bang.span=> {#asteracea::bump_format!#args}),
 		|input| PartBody::<C>::parse_with_context(input, cx),

--- a/proc-macro-definitions/src/part/event_binding.rs
+++ b/proc-macro-definitions/src/part/event_binding.rs
@@ -1,11 +1,11 @@
 use super::capture_definition::CaptureDefinition;
 use crate::{
-	asteracea_ident,
+	asteracea_crate,
 	storage_context::{ParseContext, ParseWithContext},
 	workaround_module::Configuration,
 };
 use call2_for_syn::call2_strict;
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::quote_spanned;
 use syn::{
 	braced,
@@ -120,8 +120,8 @@ impl EventBindingDefinition {
 			name,
 			field_name,
 		} = self;
-		let asteracea = asteracea_ident(prefix.span);
-		let self_ident = Ident::new("self", Span::call_site());
+		let asteracea = asteracea_crate();
+		let self_ident = Ident::new("self", prefix.span);
 
 		quote_spanned! {name.span()=>
 			#asteracea::lignin::EventBinding {

--- a/proc-macro-definitions/src/part/html_comment.rs
+++ b/proc-macro-definitions/src/part/html_comment.rs
@@ -1,5 +1,5 @@
 use crate::{
-	asteracea_ident,
+	asteracea_crate,
 	storage_context::{ParseContext, ParseWithContext},
 };
 use proc_macro2::{Span, TokenStream};
@@ -33,7 +33,7 @@ impl HtmlComment {
 			ref text,
 		} = self;
 
-		let asteracea = asteracea_ident(open_span);
+		let asteracea = asteracea_crate();
 
 		quote_spanned! {open_span=>
 			#asteracea::lignin::Node::Comment(

--- a/proc-macro-definitions/src/part/html_definition.rs
+++ b/proc-macro-definitions/src/part/html_definition.rs
@@ -1,6 +1,6 @@
 use super::{GenerateContext, Part, PartKind};
 use crate::{
-	asteracea_ident,
+	asteracea_crate,
 	storage_context::{ParseContext, ParseWithContext},
 	Configuration,
 };
@@ -207,9 +207,9 @@ impl<C: Configuration> HtmlDefinition<C> {
 			parts,
 		} = self;
 
-		let asteracea = asteracea_ident(lt.span());
+		let asteracea = asteracea_crate();
 
-		let bump = Ident::new("bump", lt.span().resolved_at(Span::call_site()));
+		let bump = Ident::new("bump", lt.span());
 
 		let has_optional_attributes = attributes.iter().any(|a| match a {
 			AttributeDefinition::Assignment(_, _, Some(Question { .. }), _, _) => true,
@@ -293,7 +293,7 @@ impl<C: Configuration> HtmlDefinition<C> {
 		}
 		let children = quote_spanned! {child_stream.span()=>
 			&*#bump.alloc_try_with(
-				|| -> ::std::result::Result<_, ::#asteracea::error::Escalation> {
+				|| -> ::std::result::Result<_, #asteracea::error::Escalation> {
 					::std::result::Result::Ok([#child_stream])
 				}
 			)?

--- a/proc-macro-definitions/src/storage_configuration.rs
+++ b/proc-macro-definitions/src/storage_configuration.rs
@@ -16,7 +16,7 @@ use syn::{
 use unquote::unquote;
 use wyz::Pipe;
 
-use crate::{asteracea_ident, storage_context::StorageContext};
+use crate::{asteracea_crate, storage_context::StorageContext};
 
 /// ⟦⦃priv‖⦅Visibility⦆⦄ …⦅StorageTypeConfiguration⦆⟧
 #[allow(clippy::large_enum_variant)]
@@ -463,9 +463,9 @@ impl StorageTypeConfiguration {
 					::std::compile_error!("Asteracea can't soundly generate named generic storage context types if anything inside requires pinning :(\n(Once min_specialization lands, the required static assert against `Self: Unpin` will become available. For now, please use a `box <…>`-expression with either anonymous or manually defined storage context type to pin any child components in a heap allocation.)\n\nSee also: https://github.com/Tamschi/Asteracea/pull/31");
 				}
 			} else {
-				let asteracea = asteracea_ident(span);
+				let asteracea = asteracea_crate();
 				quote_spanned! {span=>
-					::#asteracea::__Asteracea__implementation_details::static_assertions::assert_not_impl_any!(#ident: ::std::marker::Unpin);
+					#asteracea::__Asteracea__implementation_details::static_assertions::assert_not_impl_any!(#ident: ::std::marker::Unpin);
 				}
 			}))
 			}

--- a/proc-macro-definitions/src/trace_instrumentation.rs
+++ b/proc-macro-definitions/src/trace_instrumentation.rs
@@ -1,4 +1,4 @@
-use crate::asteracea_ident;
+use crate::asteracea_crate;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
 use syn::{parse::Parse, spanned::Spanned, token::Brace, Token};
@@ -22,7 +22,7 @@ impl ToTokens for Tracing {
 	fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
 		ItemFn {
 			block: {
-				let asteracea = asteracea_ident(Span::mixed_site());
+				let asteracea = asteracea_crate();
 				let statements = &self.function.block.stmts;
 				let prefix = &self.prefix;
 				let joiner = prefix.as_ref().map(|p| if p.is_empty() {
@@ -32,7 +32,7 @@ impl ToTokens for Tracing {
 				}).flatten();
 				let name = &self.function.sig.ident;
 				let inner = quote_spanned! {self.function.sig.output.span().resolved_at(Span::mixed_site())=>
-					let result = ::#asteracea::error::Escalation::catch_any(::std::panic::AssertUnwindSafe(
+					let result = #asteracea::error::Escalation::catch_any(::std::panic::AssertUnwindSafe(
 						// UNWIND-SAFETY: Any panic caught here is resumed when the captured `Caught` is escalated.
 						|| { #statements }
 					));

--- a/src/error.rs
+++ b/src/error.rs
@@ -173,6 +173,7 @@ pub struct Caught<E: ?Sized> {
 	// An error or panic.
 	boxed: Box<E>,
 	trace: Option<Vec<Cow<'static, str>>>,
+	/// This (in general) exists to preserve unwind safety speed bumps.
 	was_panic: bool,
 }
 impl<E: ?Sized> Caught<E> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 #![allow(clippy::match_bool)]
 #![allow(clippy::redundant_closure_for_method_calls)]
 
-pub use asteracea_proc_macro_definitions::{bump_format, component, fragment, trace_escalations};
 pub use lignin;
 pub use rhizome;
 
@@ -32,6 +31,34 @@ pub mod readme {
 }
 
 pub mod error;
+
+#[doc(hidden)]
+pub mod macros {
+	pub use asteracea_proc_macro_definitions::{bump_format, component, fragment};
+}
+
+pub use asteracea_proc_macro_definitions::trace_escalations;
+
+#[macro_export]
+macro_rules! bump_format {
+	($($tokens:tt)*) => {
+		$crate::macros::bump_format!($crate, $($tokens)*)
+	};
+}
+
+#[macro_export]
+macro_rules! component {
+	($($tokens:tt)*) => {
+		$crate::macros::component!($crate, $($tokens)*);
+	};
+}
+
+#[macro_export]
+macro_rules! fragment {
+	($($tokens:tt)*) => {
+		$crate::macros::fragment!($crate, $($tokens)*)
+	};
+}
 
 #[cfg(feature = "services")]
 pub mod services;


### PR DESCRIPTION
Will close #38.

I'm putting this on ice for now since rust-analyzer doesn't seem to resolve macros through `$crate` yet:

![image](https://user-images.githubusercontent.com/715360/106398619-2fdbf580-6414-11eb-9611-4719926a6002.png)