### PR TITLE
Minimal transclusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,8 +49,10 @@ dependencies = [
  "bumpalo",
  "cargo-husky",
  "debugless-unwrap 0.0.4",
+ "ergo-pin",
  "git_info",
  "lignin",
+ "lignin-html",
  "lignin-schema",
  "rhizome",
  "static_assertions",
@@ -300,6 +302,17 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "ergo-pin"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc1eb88aabef58f4b6ebfa4e5d644bf6e832a39a0fba225c120605580f4a30b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,9 @@ typed-builder = "0.9.0" # semi-public
 [dev-dependencies]
 cargo-husky = "1.5.0"
 debugless-unwrap = "0.0.4"
+ergo-pin = "0.1.0"
 git_info = "0.1.2"
+lignin-html = { git = "https://github.com/Tamschi/lignin-html.git", branch = "develop" }
 tap = "1.0.1"
 version-sync = "0.9.1"
 wasm-bindgen-test = "0.3.27"

--- a/proc-macro-definitions/src/part/component.rs
+++ b/proc-macro-definitions/src/part/component.rs
@@ -1,9 +1,11 @@
 use std::{collections::HashSet, iter};
 
-use super::CaptureDefinition;
+use super::{CaptureDefinition, GenerateContext};
 use crate::{
 	asteracea_ident,
+	part::Part,
 	storage_context::{ParseContext, ParseWithContext},
+	workaround_module::Configuration,
 };
 use call2_for_syn::call2_strict;
 use proc_macro2::{Punct, Span, TokenStream};
@@ -17,20 +19,25 @@ use syn::{
 	Visibility,
 };
 use syn_mid::Block;
+use tap::Pipe;
 use unquote::unquote;
 
-pub enum Component<C> {
+pub enum Component<C: Configuration> {
 	Instantiated {
+		open_span: Span,
+		path: ExprPath,
 		capture: CaptureDefinition<C>,
-		render_call: TokenStream,
+		render_params: Vec<Parameter>,
+		content_children: Vec<ContentChild<C>>,
 	},
 	Instanced {
 		open_span: Span,
 		reference: Block,
 		render_params: Vec<Parameter>,
+		content_children: Vec<ContentChild<C>>,
 	},
 }
-impl<C> ParseWithContext for Component<C> {
+impl<C: Configuration> ParseWithContext for Component<C> {
 	type Output = Self;
 
 	fn parse_with_context(input: ParseStream<'_>, cx: &mut ParseContext) -> Result<Self::Output> {
@@ -45,25 +52,34 @@ impl<C> ParseWithContext for Component<C> {
 			reference.brace_token.span = reference.brace_token.span.resolved_at(Span::mixed_site());
 
 			let mut render_params = vec![];
-			loop {
-				if input.peek(Token![.]) {
-					unquote!(input, #let param);
-					render_params.push(param)
-				} else if input.peek(Token![>]) {
-					unquote!(input, >);
-					break;
-				} else {
-					return Err(Error::new(
-						input.span(),
-						"Expected .render_arg or `>` (end of child component element)",
-					));
+			while input.peek(Token![.]) && !input.peek(Token![..]) {
+				unquote!(input, #let param);
+				render_params.push(param)
+			}
+
+			let mut content_children = vec![];
+			while !input.peek(Token![>]) {
+				let span = input.span();
+				let part = Part::<C>::parse_with_context(input, cx)?;
+				if let Some(part) = part {
+					content_children.push(ContentChild { span, part })
 				}
+			}
+
+			if input.peek(Token![>]) {
+				unquote!(input, >);
+			} else {
+				return Err(Error::new(
+					input.span(),
+					"Expected .render_arg or content child or `>` (end of child component element)",
+				));
 			}
 
 			Ok(Self::Instanced {
 				open_span,
 				reference,
 				render_params,
+				content_children,
 			})
 		} else {
 			// TypePath actually would lead to a better error message here (regarding ::<> use),
@@ -91,48 +107,60 @@ impl<C> ParseWithContext for Component<C> {
 			};
 
 			let mut new_params: Vec<Parameter> = vec![];
+			while input.peek(Token![*]) {
+				new_params.push(input.parse()?)
+			}
+
 			let mut render_params: Vec<Parameter> = vec![];
-			loop {
-				if input.peek(Token![*]) {
-					new_params.push(input.parse()?)
-				} else if input.peek(Token![.]) {
-					render_params.push(input.parse()?)
-				} else if input.peek(Token![/]) {
-					let closing_name: Ident;
-					unquote!(input, /#closing_name>);
-					if closing_name != path.path.segments.last().ok_or_else(|| Error::new_spanned(path.clone(), "Strange: This path doesn't contain a last segment... Somehow. It's needed for named element closing, so maybe don't do that here."))?.ident {
+			while input.peek(Token![.]) && !input.peek(Token![..]) {
+				unquote!(input, #let param);
+				render_params.push(param)
+			}
+
+			let mut content_children = vec![];
+			while !input.peek(Token![>]) {
+				let span = input.span();
+				let part = Part::<C>::parse_with_context(input, cx)?;
+				if let Some(part) = part {
+					content_children.push(ContentChild { span, part })
+				}
+			}
+
+			if input.peek(Token![/]) {
+				let closing_name: Ident;
+				unquote!(input, /#closing_name>);
+				if closing_name != path.path.segments.last().ok_or_else(|| Error::new_spanned(path.clone(), "Strange: This path doesn't contain a last segment... Somehow. It's needed for named element closing, so maybe don't do that here."))?.ident {
 						return Err(Error::new_spanned(
 							closing_name,
 							format!("Expected `{}`", path.path.segments.last().unwrap().ident.to_string()),
 						));
 					}
-					break;
-				} else if input.peek(Token![>]) {
-					unquote!(input, >);
-					break;
-				} else {
-					return Err(Error::new(
-						input.span(),
-						if let Some(last) = path.path.segments.last() {
-							format!("Expected .render_arg or `/{}>` or `>` (end of child component element)", last.ident.to_string())
-						} else {
-							"Expected .render_arg or `>` (end of child component element)"
-								.to_string()
-						},
-					));
-				}
+			} else if input.peek(Token![>]) {
+				unquote!(input, >);
+			} else {
+				return Err(Error::new(
+					input.span(),
+					if let Some(last) = path.path.segments.last() {
+						format!("Expected .render_arg or content child or `/{}>` or `>` (end of child component element)", last.ident.to_string())
+					} else {
+						"Expected .render_arg or content child or `>` (end of child component element)".to_string()
+					},
+				));
 			}
 
-			let new_params = parameter_struct_expression(
+			let new_params = parameter_struct_expression::<C>(
+				None,
 				open_span,
 				parse2(quote_spanned! (open_span=> #path::new_args_builder()))
 					.expect("new_params make_builder"),
 				new_params.as_slice(),
-			);
+				&[],
+			)?;
 
 			Ok(Self::Instantiated {
-			capture: call2_strict(
-				quote_spanned! {open_span=>
+				open_span,
+				capture: call2_strict(
+					quote_spanned! {open_span=>
 						pin |#visibility #field_name = #path::new(&node, #new_params)?|
 					},
 					|input| CaptureDefinition::<C>::parse_with_context(input, cx),
@@ -140,26 +168,35 @@ impl<C> ParseWithContext for Component<C> {
 				.map_err(|_| Error::new(open_span, "Internal Asteracea error: Child component element didn't produce parseable capture"))?
 				.map_err(|_| Error::new(open_span, "Internal Asteracea error: Child component element didn't produce parseable capture"))?
 				.expect("Component::parse_with_context capture"),
-			render_call: {
-				let render_params = parameter_struct_expression(
-					open_span.resolved_at(Span::mixed_site()),
-					parse2(quote_spanned! (open_span.resolved_at(Span::mixed_site())=> #path::render_args_builder())).expect("render_params make_builder 1"),
-					render_params.as_slice(),
-				);
-				quote_spanned! (open_span=> .render(bump, #render_params)? )
-			}
+				path,
+			render_params,
+			content_children,
 		})
 		}
 	}
 }
 
-impl<C> Component<C> {
-	pub fn part_tokens(&self) -> TokenStream {
+impl<C: Configuration> Component<C> {
+	pub fn part_tokens(&self, cx: &GenerateContext) -> Result<TokenStream> {
 		match self {
 			Component::Instantiated {
+				open_span,
 				capture,
-				render_call,
+				path,
+				render_params,
+				content_children,
 			} => {
+let render_call= {
+	let render_params = parameter_struct_expression(
+		Some(cx),
+		open_span.resolved_at(Span::mixed_site()),
+		parse2(quote_spanned! (open_span.resolved_at(Span::mixed_site())=> #path::render_args_builder())).expect("render_params make_builder 1"),
+		render_params.as_slice(),
+		content_children.as_slice(),
+	)?;
+	quote_spanned!(*open_span=> .render(bump, #render_params)?)
+};
+
 				let asteracea = asteracea_ident(Span::mixed_site());
 				let mut expr = parse2(quote!({
 					let rendered = #capture#render_call;
@@ -178,17 +215,20 @@ impl<C> Component<C> {
 				open_span,
 				reference,
 				render_params,
+				content_children,
 			} => {
 				let asteracea = asteracea_ident(*open_span);
 				let binding = quote_spanned!(reference.brace_token.span.resolved_at(Span::mixed_site())=> let reference: ::std::pin::Pin<&_> = #reference;);
 				let bump = quote_spanned!(*open_span=> bump);
 				let render_params = parameter_struct_expression(
+					Some(cx),
 					open_span.resolved_at(Span::mixed_site()),
 					parse2(
 						quote_spanned!(open_span.resolved_at(Span::mixed_site())=> reference.__Asteracea__ref_render_args_builder()),
 					).expect("render_params make_builder 2"),
 					render_params.as_slice(),
-				);
+					content_children.as_slice(),
+				)?;
 				let mut expr = parse2(quote_spanned!(open_span.resolved_at(Span::mixed_site())=> {
 					#binding
 					let rendered = reference.render(#bump, #render_params)?;
@@ -203,7 +243,7 @@ impl<C> Component<C> {
 				visit_expr_mut(&mut SelfMassager, &mut expr);
 				quote!(#expr)
 			}
-		}
+		}.pipe(Ok)
 	}
 }
 
@@ -260,11 +300,13 @@ impl ToTokens for Parameter {
 	}
 }
 
-fn parameter_struct_expression(
+fn parameter_struct_expression<C: Configuration>(
+	cx: Option<&GenerateContext>,
 	fallback_span: Span,
 	make_builder: Expr,
 	parameters: &[Parameter],
-) -> TokenStream {
+	content_children: &[ContentChild<C>],
+) -> Result<TokenStream> {
 	if parameters
 		.iter()
 		.all(|parameter| parameter.question.is_none())
@@ -290,10 +332,21 @@ fn parameter_struct_expression(
 				},
 			)
 			.collect::<Vec<_>>();
+		let content_children = content_children
+			.iter()
+			.map(|content_child| content_child.parameter_tokens(cx.expect("`GenerateContent` is required here.")))
+			.collect::<Result<Vec<_>>>()?;
 		quote_spanned! {fallback_span=>
-			#make_builder#(#parameters)*.build()
+			#make_builder
+				#(#parameters)*
+				#(#content_children)*
+				.build()
 		}
 	} else {
+		if !content_children.is_empty() {
+			todo!("Content children in the presence of optional parameters")
+		}
+
 		let mut deferred_names = HashSet::new();
 
 		let mut deferred = vec![];
@@ -432,6 +485,31 @@ fn parameter_struct_expression(
 				#(#match_arms)*
 			}
 		}}
+	}.pipe(Ok)
+}
+
+pub struct ContentChild<C: Configuration> {
+	span: Span,
+	part: Part<C>,
+}
+
+impl<C: Configuration> ContentChild<C> {
+	fn parameter_tokens(&self, cx: &GenerateContext) -> Result<TokenStream> {
+		let part = self.part.part_tokens(cx)?;
+
+		let span = self.span.resolved_at(Span::mixed_site());
+		let bump = Ident::new("bump", span.resolved_at(Span::call_site()));
+		let bump_time = quote_spanned!(bump.span()=> 'bump);
+		let asteracea = asteracea_ident(span);
+		quote_spanned! {span=>
+			.__Asteracea__anonymous_content(::std::boxed::Box::new(
+				|bump: &#bump_time ::#asteracea::bumpalo::Bump| -> ::std::result::Result<_, ::#asteracea::error::Escalation> {
+					::core::result::Result::Ok(#part)
+				}
+			))
+		}
+		.to_token_stream()
+		.pipe(Ok)
 	}
 }
 

--- a/proc-macro-definitions/src/part/component.rs
+++ b/proc-macro-definitions/src/part/component.rs
@@ -118,7 +118,7 @@ impl<C: Configuration> ParseWithContext for Component<C> {
 			}
 
 			let mut content_children = vec![];
-			while !input.peek(Token![>]) {
+			while !input.peek(Token![/]) && !input.peek(Token![>]) {
 				let span = input.span();
 				let part = Part::<C>::parse_with_context(input, cx)?;
 				if let Some(part) = part {

--- a/proc-macro-definitions/src/part/content.rs
+++ b/proc-macro-definitions/src/part/content.rs
@@ -1,0 +1,28 @@
+use crate::storage_context::{ParseContext, ParseWithContext};
+use proc_macro2::{Span, TokenStream};
+use quote::quote_spanned;
+use syn::{parse::ParseStream, spanned::Spanned, Ident, Result, Token};
+
+pub struct Content {
+	//TODO: For multi-use, accept `Token![...]`.
+	dot2: Token![..],
+}
+
+impl ParseWithContext for Content {
+	type Output = Self;
+
+	fn parse_with_context(input: ParseStream<'_>, _cx: &mut ParseContext) -> Result<Self::Output> {
+		Ok(Self {
+			dot2: input.parse()?,
+		})
+	}
+}
+
+impl Content {
+	pub fn part_tokens(&self) -> TokenStream {
+		let bump = Ident::new("bump", self.dot2.span());
+		quote_spanned! {self.dot2.span().resolved_at(Span::mixed_site())=>
+			__Asteracea__anonymous_content(#bump)?
+		}
+	}
+}

--- a/proc-macro-definitions/src/part/html_definition.rs
+++ b/proc-macro-definitions/src/part/html_definition.rs
@@ -134,7 +134,8 @@ impl<C: Configuration> ParseWithContext for HtmlDefinition<C> {
 
 		let attributes = {
 			let mut attributes = Vec::new();
-			while let Ok(dot) = input.parse::<Token![.]>() {
+			while input.peek(Token![.]) && !input.peek(Token![..]) {
+				let dot = input.parse::<Token![.]>().expect("unreachable");
 				attributes.push(if input.peek(Ident) || input.peek(LitStr) {
 					let key;
 					let question: Option<Token![?]>;

--- a/tests/content.rs
+++ b/tests/content.rs
@@ -1,3 +1,7 @@
+use bumpalo::Bump;
+use ergo_pin::ergo_pin;
+use rhizome::Node;
+
 asteracea::component! {
 	Container()(..)
 
@@ -13,9 +17,27 @@ asteracea::component! {
 }
 
 asteracea::component! {
-	Parent()()
+	Parent()() -> Sync
 
 	<*Container
 		<*Content>
 	>
+}
+
+#[test]
+#[ergo_pin]
+fn content_in_container() {
+	let root = Node::new_for::<()>().into_arc();
+	let parent = pin!(Parent::new(&root, Parent::new_args_builder().build()).unwrap());
+	let bump = Bump::new();
+	let vdom = parent
+		.as_ref()
+		.render(&bump, Parent::render_args_builder().build())
+		.unwrap();
+	let mut html = String::new();
+	lignin_html::render_fragment(&vdom, &mut html, 3).unwrap();
+	assert_eq!(
+		html,
+		"<custom-container><custom-content></custom-content></custom-container>"
+	)
 }

--- a/tests/content.rs
+++ b/tests/content.rs
@@ -1,0 +1,21 @@
+asteracea::component! {
+	Container()(..)
+
+	<"custom-container"
+		..
+	>
+}
+
+asteracea::component! {
+	Content()()
+
+	<"custom-content">
+}
+
+asteracea::component! {
+	Parent()()
+
+	<*Container
+		<*Content>
+	>
+}


### PR DESCRIPTION
This adds minimal support for content transclusion as in the following code:

```rust
asteracea::component! {
	Container()(..)

	<"custom-container"
		..
	>
}

asteracea::component! {
	Content()()

	<"custom-content">
}

asteracea::component! {
	Parent()() -> Sync

	<*Container
		<*Content>
	>
}
```

- - -

For now:

- only transclusion of content that renders into a thread-safe VDOM is supported,
- only one child expression is supported.