### PR TITLE
`for`-loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,7 +530,7 @@ checksum = "9e69cdf6b85b5c8dce514f694089a2cf8b1a702f6cd28607bcb3cf296c9778db"
 [[package]]
 name = "linotype"
 version = "0.0.1"
-source = "git+https://github.com/Tamschi/linotype.git?branch=develop#3bcaeb28134b90d607c5bbbef09ad9f801147047"
+source = "git+https://github.com/Tamschi/linotype.git?branch=develop#4d6b31cbd3975cf23f8bc9f8bc1f02cdcc27821f"
 dependencies = [
  "scopeguard",
  "tap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "lignin",
  "lignin-html",
  "lignin-schema",
+ "linotype",
  "rhizome",
  "static_assertions",
  "tap",
@@ -525,6 +526,16 @@ name = "line-col"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e69cdf6b85b5c8dce514f694089a2cf8b1a702f6cd28607bcb3cf296c9778db"
+
+[[package]]
+name = "linotype"
+version = "0.0.1"
+source = "git+https://github.com/Tamschi/linotype.git?branch=develop#3bcaeb28134b90d607c5bbbef09ad9f801147047"
+dependencies = [
+ "scopeguard",
+ "tap",
+ "typed-arena",
+]
 
 [[package]]
 name = "lock_api"
@@ -1453,6 +1464,12 @@ name = "try-lazy-init"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8da954976b3cfd8a4d73b3ebb573e4b0f4c92326e5c1366a1c7b11e1eb11745"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typed-builder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "higher-order-closure"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c450d87a307c754cbd7718dfca84b8904e313157191fae5b249d37aab216c89"
+
+[[package]]
 name = "html5ever"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,8 +536,10 @@ checksum = "9e69cdf6b85b5c8dce514f694089a2cf8b1a702f6cd28607bcb3cf296c9778db"
 [[package]]
 name = "linotype"
 version = "0.0.1"
-source = "git+https://github.com/Tamschi/linotype.git?branch=develop#4d6b31cbd3975cf23f8bc9f8bc1f02cdcc27821f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "265f5d4bcc8cd79556fb80b2a140dd477d2b01c9016d04ad9a315559d49a2e1e"
 dependencies = [
+ "higher-order-closure",
  "scopeguard",
  "tap",
  "typed-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ rhizome = { version = "0.0.1", features = ["macros"] } # public
 static_assertions = "1.1.0"
 typed-builder = "0.9.0" # semi-public
 tracing = { version = "0.1.29", optional = true, default-features = false }
+linotype = { git = "https://github.com/Tamschi/linotype.git", branch = "develop" }
 
 [dev-dependencies]
 cargo-husky = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,11 +52,11 @@ bumpalo = { version = "3.6.1", features = ["collections"] } # public
 try-lazy-init = "0.0.2"
 lignin = "0.1.0" # public
 lignin-schema = { git = "https://github.com/Tamschi/lignin-schema.git", branch = "develop" } # semi-public
+linotype = { version = "0.0.1" }
 rhizome = { version = "0.0.1", features = ["macros"] } # public
 static_assertions = "1.1.0"
 typed-builder = "0.9.0" # semi-public
 tracing = { version = "0.1.29", optional = true, default-features = false }
-linotype = { git = "https://github.com/Tamschi/linotype.git", branch = "develop" }
 
 [dev-dependencies]
 cargo-husky = "1.5.0"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -35,7 +35,7 @@
   - [`spread if {…} <…>`](./conditional_content/spread_if.md)
   - [`spread if …… else <…>`](./conditional_content/spread_if_else.md)
   - [`dyn if {…} ⟦as ⟦pub⟧ …⟦: ⟦enum⟧ …⟧⟧ ⟦dyn ⟦move⟧⟧ <…> ⟦else ⟦dyn ⟦move⟧⟧ <…>⟧`]()
-  - [`for … in <…> by <…> ⟦priv …⟦: ⟦struct⟧ …⟧⟧ <…> ⟦else <…>⟧`]()
+  - [`for`-loops](./conditional_content/for.md)
   - [`spread match { … } [ … ]`](./conditional_content/spread_match.md)
   - [`dyn match <…> [ … ]`]()
   - [`box ⟦priv …⟦: ⟦struct⟧ … ⟦where …;⟧⟧⟧ <…>`](./conditional_content/box.md)

--- a/book/src/conditional_content/for.md
+++ b/book/src/conditional_content/for.md
@@ -6,9 +6,9 @@
 asteracea::component! {
   pub Looping()() -> Sync
 
-  for c: &str in "This is a test.".split(' ') {[
+  for word in "This is a test.".split(' ') {[
       <li
-        !"{:?}"(c)
+        !"{:?}"(word)
       > "\n"
   ]}
 }
@@ -45,8 +45,10 @@ asteracea::component! {
 
 where
 
+- `i` is the item pattern, used both for the loop body (by value) and the selector,
 - `: ⦃T⦄` determines the type of items in the sequence,
-- `keyed ⦃selector⦄` projects `&mut T` to `&Q` where `Q: Eq + ToOwned<Owned = K>` and
-- `=> ⦃K⦄` where `K: ReprojectionKey` determines the type of state keys cached internally.
+- `keyed ⦃selector⦄` projects `&mut T` to `&Q` where `Q: Eq + ToOwned<Owned = K>`,
+- `=> ⦃K⦄` where `K: ReprojectionKey` determines the type of state keys cached internally and
+- `0..255` is an [`IntoIterator`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) to use as item source.
 
-Each of these parts is optional, but currently at least some are required for type resolution. This requirement is expected to disappear with [future Rust language improvements](https://github.com/rust-lang/rust/issues/63063).
+Each of these parts is optional, but currently it may be occasionally necessary to specify a type. **Specifying neither `T` nor `K` also means a loop will use somewhat less efficient dynamically typed stored keys that always incur a heap allocation when an item is added to the list.** Both most annotation requirements and relative inefficiency of unannotated loops is expected to disappear with [future Rust language improvements](https://github.com/rust-lang/rust/issues/63063).

--- a/book/src/conditional_content/for.md
+++ b/book/src/conditional_content/for.md
@@ -48,3 +48,5 @@ where
 - `: ⦃T⦄` determines the type of items in the sequence,
 - `keyed ⦃selector⦄` projects `&mut T` to `&Q` where `Q: Eq + ToOwned<Owned = K>` and
 - `=> ⦃K⦄` where `K: ReprojectionKey` determines the type of state keys cached internally.
+
+Each of these parts is optional, but currently at least some are required for type resolution. This requirement is expected to disappear with [future Rust language improvements](https://github.com/rust-lang/rust/issues/63063).

--- a/book/src/conditional_content/for.md
+++ b/book/src/conditional_content/for.md
@@ -2,9 +2,9 @@
 
 `for` loops in Asteracea components resemble those in plain Rust, but do produce output on each iteration:
 
-```rust asteracea=Looped
+```rust asteracea=Looping
 asteracea::component! {
-  pub Looped()() -> Sync
+  pub Looping()() -> Sync
 
   for c: &str in "This is a test.".split(' ') {[
       <li
@@ -13,3 +13,38 @@ asteracea::component! {
   ]}
 }
 ```
+
+You can declare bindings and use child components within the loop's body as normal.
+
+Their state is:
+
+- initialised anew for each new element,
+- "stuck" to the respective element in the input sequence when it is reordered and
+- dropped if an element has disappeared.
+
+Repeated elements each have their own state, but are considered interchangeable.
+Each such group's state "list" is auto-edited only at the end.
+
+> DOM elements are also reordered for sequence updates, but this isn't entirely reliable if you use keys longer than 32 bits.
+>
+> This is guaranteed to never cause an inconsistent GUI state (since any output and bindings will still be updated to be in the correct order when diffing), but in very rare cases could result in a selection or focus "jumping elsewhere".
+>
+> Such glitches are guaranteed to never happen while the sequence is stable, however.
+
+The full explicit syntax for `for`-loops is as follows:
+
+```rust asteracea=Looping
+asteracea::component! {
+  pub Looping()() -> Sync
+
+  for i: u8 keyed &*i => u8 in 0..255 {
+    "."
+  }
+}
+```
+
+where
+
+- `: ⦃T⦄` determines the type of items in the sequence,
+- `keyed ⦃selector⦄` projects `&mut T` to `&Q` where `Q: Eq + ToOwned<Owned = K>` and
+- `=> ⦃K⦄` where `K: ReprojectionKey` determines the type of state keys cached internally.

--- a/book/src/conditional_content/for.md
+++ b/book/src/conditional_content/for.md
@@ -1,0 +1,15 @@
+# `for`-loops
+
+`for` loops is Asteracea components resemble those in plain Rust, but do produce output on each iteration:
+
+```rust asteracea=Looped
+asteracea::component! {
+  pub Looped()() -> Sync
+
+  for c: &str in "This is a test.".split(' ') {[
+      <li
+        !"{:?}"(c)
+      > "\n"
+  ]}
+}
+```

--- a/book/src/conditional_content/for.md
+++ b/book/src/conditional_content/for.md
@@ -1,6 +1,6 @@
 # `for`-loops
 
-`for` loops is Asteracea components resemble those in plain Rust, but do produce output on each iteration:
+`for` loops in Asteracea components resemble those in plain Rust, but do produce output on each iteration:
 
 ```rust asteracea=Looped
 asteracea::component! {

--- a/proc-macro-definitions/src/part/for_.rs
+++ b/proc-macro-definitions/src/part/for_.rs
@@ -9,7 +9,7 @@ use crate::{
 use call2_for_syn::call2_strict;
 use debugless_unwrap::{DebuglessUnwrap, DebuglessUnwrapNone};
 use proc_macro2::{Span, TokenStream};
-use quote::{quote_spanned, IdentFragment};
+use quote::quote_spanned;
 use syn::{Expr, Ident, Pat, Result, Token};
 use tap::Pipe;
 use unquote::unquote;
@@ -19,6 +19,7 @@ mod kw {
 	custom_keyword!(keyed);
 }
 
+#[allow(dead_code)]
 pub struct For<C: Configuration> {
 	for_: Token![for],
 	field_name: Ident,
@@ -112,7 +113,7 @@ impl<C: Configuration> ParseWithContext for For<C> {
 			cx.assorted_items.extend(
 				type_configuration.struct_definition(
 					vec![],
-					visibility.clone(),
+					visibility,
 					type_path
 						.path
 						.segments

--- a/proc-macro-definitions/src/part/for_.rs
+++ b/proc-macro-definitions/src/part/for_.rs
@@ -97,7 +97,7 @@ impl<C: Configuration> ParseWithContext for For<C> {
 						::new({
 							#[allow(unused_variables)]
 							let #node = ::std::sync::Arc::clone(&#node);
-							move |_| Ok(#manufactured_item_state)
+							move || Ok(#manufactured_item_state)
 						})
 				|;
 			},

--- a/proc-macro-definitions/src/part/for_.rs
+++ b/proc-macro-definitions/src/part/for_.rs
@@ -1,7 +1,17 @@
 use super::{GenerateContext, Part};
-use crate::{storage_context::ParseWithContext, workaround_module::Configuration};
-use proc_macro2::TokenStream;
-use syn::{Expr, Pat, Result, Token};
+use crate::{
+	asteracea_ident,
+	part::{BlockParentParameters, CaptureDefinition},
+	storage_configuration::{StorageConfiguration, StorageTypeConfiguration},
+	storage_context::ParseWithContext,
+	workaround_module::Configuration,
+};
+use call2_for_syn::call2_strict;
+use debugless_unwrap::{DebuglessUnwrap, DebuglessUnwrapNone};
+use proc_macro2::{Span, TokenStream};
+use quote::{quote_spanned, IdentFragment};
+use syn::{Expr, Ident, Pat, Result, Token};
+use tap::Pipe;
 use unquote::unquote;
 
 mod kw {
@@ -11,6 +21,8 @@ mod kw {
 
 pub struct For<C: Configuration> {
 	for_: Token![for],
+	field_name: Ident,
+	type_configuration: StorageTypeConfiguration,
 	pat: Pat,
 	keyed: kw::keyed,
 	key: Expr,
@@ -31,8 +43,11 @@ impl<C: Configuration> ParseWithContext for For<C> {
 		//TODO: Very broken, refactor this into `Part` in general and just have these preface any part.
 		parent_parameter_parser.parse_any(input, cx)?;
 
+		let storage_configuration: StorageConfiguration;
+		let for_: Token![for];
 		unquote! {input,
-			#let for_
+			#for_
+			#storage_configuration
 			#let pat
 			#let keyed
 			#let key
@@ -40,13 +55,83 @@ impl<C: Configuration> ParseWithContext for For<C> {
 			#let iterable
 			#let comma
 		};
+
+		let visibility = storage_configuration.visibility();
+		let field_name = storage_configuration
+			.field_name()
+			.cloned()
+			.unwrap_or_else(|| cx.storage_context.next_field(for_.span));
+		let type_configuration = storage_configuration.type_configuration();
+		let nested_generics = type_configuration.generics()?;
+		let auto_generics = nested_generics.is_none();
+		let nested_generics = nested_generics.unwrap_or_else(|| cx.storage_generics.clone());
+
+		let mut parse_context = cx.new_nested(
+			cx.storage_context.generated_type_name(&field_name),
+			&nested_generics,
+		);
+
 		let content = Box::new(Part::parse_required_with_context(
 			input,
-			cx,
+			&mut parse_context,
 			parent_parameter_parser,
 		)?);
+
+		let type_path =
+			type_configuration.type_path(&cx.storage_context, &field_name, cx.storage_generics)?;
+
+		let manufactured_item_state = parse_context.storage_context.value(
+			type_configuration.type_is_generated(),
+			&type_path,
+			auto_generics,
+		);
+
+		let asteracea = asteracea_ident(for_.span);
+		let node = quote_spanned!(for_.span=> node);
+		call2_strict(
+			quote_spanned! {for_.span.resolved_at(Span::mixed_site())=>
+				pin |
+					#visibility #field_name =
+						::#asteracea::storage::For::<'static, #type_path>
+						::new({
+							#[allow(unused_variables)]
+							let #node = ::std::sync::Arc::clone(&#node);
+							move |_| Ok(#manufactured_item_state)
+						})
+				|;
+			},
+			|input| {
+				CaptureDefinition::<C>::parse_with_context(input, cx, &mut BlockParentParameters)
+			},
+		)
+		.debugless_unwrap()
+		.unwrap()
+		.debugless_unwrap_none();
+
+		if type_configuration.type_is_generated() {
+			cx.assorted_items.extend(
+				type_configuration.struct_definition(
+					vec![],
+					visibility.clone(),
+					type_path
+						.path
+						.segments
+						.last()
+						.expect("`for`: generated storage type last segment")
+						.ident
+						.clone(),
+					&parse_context.storage_context,
+					cx.storage_generics,
+				)?,
+			)
+		}
+
+		cx.assorted_items.extend(parse_context.assorted_items);
+
 		Ok(Self {
 			for_,
+			field_name,
+			type_configuration,
 			pat,
 			keyed,
 			key,
@@ -60,6 +145,15 @@ impl<C: Configuration> ParseWithContext for For<C> {
 
 impl<C: Configuration> For<C> {
 	pub fn part_tokens(&self, cx: &GenerateContext) -> Result<TokenStream> {
-		todo!("for tokens")
+		let asteracea = asteracea_ident(self.for_.span);
+		let bump = Ident::new("bump", self.for_.span);
+
+		let field_name = &self.field_name;
+		let field_pinned = Ident::new(&format!("{}_pinned", field_name), field_name.span());
+
+		quote_spanned!(self.for_.span.resolved_at(Span::mixed_site())=> {
+			let for_items = ::#asteracea::bumpalo::vec![in #bump];
+		})
+		.pipe(Ok)
 	}
 }

--- a/proc-macro-definitions/src/part/for_.rs
+++ b/proc-macro-definitions/src/part/for_.rs
@@ -209,6 +209,7 @@ impl<C: Configuration> For<C> {
 			pat,
 			type_,
 			key,
+			key_type,
 			iterable,
 			brace,
 			content,
@@ -221,9 +222,15 @@ impl<C: Configuration> For<C> {
 			quote_spanned! {keyed.span.resolved_at(Span::mixed_site())=>
 				|#pat| ::core::result::Result::Ok(#key)
 			}
-		} else {
+		} else if key_type.is_none() {
 			quote_spanned! {for_span_mixed_site=>
 				|item: &mut _| ::core::result::Result::Ok(::#asteracea::__::UnBorrow::one_borrow(item))
+			}
+		} else {
+			//FIXME: This is necessary to resolve e.g. `for i => u8 in &[1, 2, 3, 4, 5]` "backwards",
+			// but is there a broader way to do that?
+			quote_spanned! {for_span_mixed_site=>
+				|item: &mut _| ::core::result::Result::Ok(::core::ops::Deref::deref(item))
 			}
 		};
 

--- a/proc-macro-definitions/src/part/for_.rs
+++ b/proc-macro-definitions/src/part/for_.rs
@@ -1,0 +1,65 @@
+use super::{GenerateContext, Part};
+use crate::{storage_context::ParseWithContext, workaround_module::Configuration};
+use proc_macro2::TokenStream;
+use syn::{Expr, Pat, Result, Token};
+use unquote::unquote;
+
+mod kw {
+	use syn::custom_keyword;
+	custom_keyword!(keyed);
+}
+
+pub struct For<C: Configuration> {
+	for_: Token![for],
+	pat: Pat,
+	keyed: kw::keyed,
+	key: Expr,
+	in_: Token![in],
+	iterable: Expr,
+	comma: Token![,],
+	content: Box<Part<C>>,
+}
+
+impl<C: Configuration> ParseWithContext for For<C> {
+	type Output = Self;
+
+	fn parse_with_context(
+		input: syn::parse::ParseStream<'_>,
+		cx: &mut crate::storage_context::ParseContext,
+		parent_parameter_parser: &mut dyn super::ParentParameterParser,
+	) -> Result<Self::Output> {
+		//TODO: Very broken, refactor this into `Part` in general and just have these preface any part.
+		parent_parameter_parser.parse_any(input, cx)?;
+
+		unquote! {input,
+			#let for_
+			#let pat
+			#let keyed
+			#let key
+			#let in_
+			#let iterable
+			#let comma
+		};
+		let content = Box::new(Part::parse_required_with_context(
+			input,
+			cx,
+			parent_parameter_parser,
+		)?);
+		Ok(Self {
+			for_,
+			pat,
+			keyed,
+			key,
+			in_,
+			iterable,
+			comma,
+			content,
+		})
+	}
+}
+
+impl<C: Configuration> For<C> {
+	pub fn part_tokens(&self, cx: &GenerateContext) -> Result<TokenStream> {
+		todo!("for tokens")
+	}
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,60 +1,7 @@
 //! State storage implementations, which are embedded into components to by certain stateful expressions.
 
-use crate::error::{Escalate, Escalation};
-use std::{
-	error::Error,
-	fmt::{self, Display, Formatter},
-	pin::Pin,
-	result::Result,
-};
-use try_lazy_init::LazyTransform;
+mod defer;
+mod for_;
 
-/// Storage for [`defer`](Defer) expressions.
-pub struct Defer<'a, Storage>(
-	LazyTransform<Box<dyn 'a + FnOnce() -> Result<Storage, Escalation>>, Storage>,
-);
-impl<'a, Storage> Defer<'a, Storage> {
-	/// Creates a new [`Defer<Storage>`] instance storing the specified constructor for later use.
-	pub fn new(
-		deferred_constructor: impl 'static + FnOnce() -> Result<Storage, Escalation>,
-	) -> Self {
-		Self(LazyTransform::new(Box::new(deferred_constructor)))
-	}
-
-	/// Retrieves a reference to the constructed `Storage`, constructing it if necessary.
-	///
-	/// # Errors
-	///
-	/// Iff construction fails, that [`Escalation`] is returned verbatim.
-	///
-	/// Iff construction failed previously, a less specific [`Escalation`] is returned without further attempts.
-	pub fn get_or_poison(self: Pin<&Self>) -> Result<Pin<&Storage>, Escalation> {
-		#[derive(Debug)]
-		struct DeferredSubexpressionConstructorFailedPreviously;
-		impl Error for DeferredSubexpressionConstructorFailedPreviously {}
-		impl Display for DeferredSubexpressionConstructorFailedPreviously {
-			fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-				f.write_str("Deferred (`defer` sub-expression) constructor failed previously.")
-			}
-		}
-
-		self.0
-			.get_or_create_or_poison(|deferred| deferred())
-			.map_err(|first_time_error| {
-				first_time_error
-					.unwrap_or_else(|| DeferredSubexpressionConstructorFailedPreviously.escalate())
-			})
-			.map(|storage| unsafe {
-				//SAFETY: Derived in place from `Pin<&Self>`.
-				Pin::new_unchecked(&*(storage as *const _))
-			})
-	}
-
-	/// Retrieves a reference to the constructed `Storage`, iff one is available already.
-	#[must_use]
-	pub fn get(self: Pin<&Self>) -> Option<Pin<&Storage>> {
-		self.0
-			.get()
-			.map(|storage| unsafe { Pin::new_unchecked(&*(storage as *const _)) })
-	}
-}
+pub use defer::Defer;
+pub use for_::For;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,7 +1,8 @@
 //! State storage implementations, which are embedded into components to by certain stateful expressions.
 
 mod defer;
-mod for_;
+#[doc(hidden)]
+pub mod for_;
 
 pub use defer::Defer;
 pub use for_::For;

--- a/src/storage/defer.rs
+++ b/src/storage/defer.rs
@@ -1,0 +1,58 @@
+use crate::error::{Escalate, Escalation};
+use std::{
+	error::Error,
+	fmt::{self, Display, Formatter},
+	pin::Pin,
+	result::Result,
+};
+use try_lazy_init::LazyTransform;
+
+/// Storage for [`defer`](`Defer`) expressions.
+pub struct Defer<'a, Storage>(
+	LazyTransform<Box<dyn 'a + FnOnce() -> Result<Storage, Escalation>>, Storage>,
+);
+impl<'a, Storage> Defer<'a, Storage> {
+	/// Creates a new [`Defer<Storage>`] instance storing the specified constructor for later use.
+	pub fn new(
+		deferred_constructor: impl 'static + FnOnce() -> Result<Storage, Escalation>,
+	) -> Self {
+		Self(LazyTransform::new(Box::new(deferred_constructor)))
+	}
+
+	/// Retrieves a reference to the constructed `Storage`, constructing it if necessary.
+	///
+	/// # Errors
+	///
+	/// Iff construction fails, that [`Escalation`] is returned verbatim.
+	///
+	/// Iff construction failed previously, a less specific [`Escalation`] is returned without further attempts.
+	pub fn get_or_poison(self: Pin<&Self>) -> Result<Pin<&Storage>, Escalation> {
+		#[derive(Debug)]
+		struct DeferredSubexpressionConstructorFailedPreviously;
+		impl Error for DeferredSubexpressionConstructorFailedPreviously {}
+		impl Display for DeferredSubexpressionConstructorFailedPreviously {
+			fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+				f.write_str("Deferred (`defer` sub-expression) constructor failed previously.")
+			}
+		}
+
+		self.0
+			.get_or_create_or_poison(|deferred| deferred())
+			.map_err(|first_time_error| {
+				first_time_error
+					.unwrap_or_else(|| DeferredSubexpressionConstructorFailedPreviously.escalate())
+			})
+			.map(|storage| unsafe {
+				//SAFETY: Derived in place from `Pin<&Self>`.
+				Pin::new_unchecked(&*(storage as *const _))
+			})
+	}
+
+	/// Retrieves a reference to the constructed `Storage`, iff one is available already.
+	#[must_use]
+	pub fn get(self: Pin<&Self>) -> Option<Pin<&Storage>> {
+		self.0
+			.get()
+			.map(|storage| unsafe { Pin::new_unchecked(&*(storage as *const _)) })
+	}
+}

--- a/src/storage/for_.rs
+++ b/src/storage/for_.rs
@@ -114,6 +114,8 @@ pub trait ReprojectionKey {
 	fn to_dom_key(&self, build_hasher: &impl BuildHasher) -> u32;
 }
 
+// TODO: Reevaluate use a hasher here. It works, but it's probably not great in terms of speed.
+
 macro_rules! impl_reprojection_keys_abs {
 	($($type:ty),*$(,)?) => {$(
 		impl ReprojectionKey for $type {
@@ -122,7 +124,7 @@ macro_rules! impl_reprojection_keys_abs {
 					assert!(mem::size_of::<$type>() <= mem::size_of::<u32>())
 				};
 				let mut hasher = build_hasher.build_hasher();
-				hasher.write_u8(0);
+				hasher.write_u8(0); // TODO: Is this necessary?
 				let base = hasher.finish() as u32;
 				base.wrapping_add((*self).wrapping_abs() as u32)
 			}

--- a/src/storage/for_.rs
+++ b/src/storage/for_.rs
@@ -1,0 +1,24 @@
+use std::pin::Pin;
+
+use linotype::Linotype;
+
+use crate::error::Escalation;
+
+/// Storage for [`for`](`For`) expressions.
+pub struct For<'a, Storage, Q: ToOwned> {
+	linotype: Pin<Linotype<Q::Owned, Storage>>,
+	factory: Box<dyn 'a + FnMut() -> Result<Storage, Escalation>>,
+}
+
+impl<'a, Storage, Q: ToOwned> For<'a, Storage, Q> {
+	pub fn new(factory: impl 'static + FnMut() -> Result<Storage, Escalation>) -> Self {
+		Self::new_(Box::new(factory))
+	}
+
+	fn new_(factory: Box<dyn 'static + FnMut() -> Result<Storage, Escalation>>) -> Self {
+		Self {
+			linotype: Linotype::new().pin(),
+			factory,
+		}
+	}
+}

--- a/src/storage/for_.rs
+++ b/src/storage/for_.rs
@@ -148,7 +148,7 @@ macro_rules! impl_reprojection_keys {
 	)*};
 }
 
-impl_reprojection_keys!(bool, u8, u16, u32);
+impl_reprojection_keys!(bool, char, u8, u16, u32);
 
 impl ReprojectionKey for u64 {
 	fn to_dom_key(&self, build_hasher: &impl BuildHasher) -> u32 {

--- a/src/storage/for_.rs
+++ b/src/storage/for_.rs
@@ -1,6 +1,5 @@
 use crate::error::Escalation;
-use core::hash::Hash;
-use core::mem;
+use core::{hash::Hash, mem};
 use linotype::{OwnedProjection, PinningOwnedProjection};
 use std::{
 	any::{Any, TypeId},

--- a/src/storage/for_.rs
+++ b/src/storage/for_.rs
@@ -1,16 +1,17 @@
-use std::pin::Pin;
+use std::{borrow::Borrow, pin::Pin};
 
-use linotype::Linotype;
+use linotype::{Linotype, PinningLinotype};
 
 use crate::error::Escalation;
 
 /// Storage for [`for`](`For`) expressions.
-pub struct For<'a, Storage, Q: ToOwned> {
-	linotype: Pin<Linotype<Q::Owned, Storage>>,
+pub struct For<'a, Storage, K = MixedKey> {
+	linotype: Pin<Linotype<K, Storage>>,
 	factory: Box<dyn 'a + FnMut() -> Result<Storage, Escalation>>,
 }
 
-impl<'a, Storage, Q: ToOwned> For<'a, Storage, Q> {
+impl<'a, Storage, K> For<'a, Storage, K> {
+	/// Creates a new instance of the [`For`] for expression storage.
 	pub fn new(factory: impl 'static + FnMut() -> Result<Storage, Escalation>) -> Self {
 		Self::new_(Box::new(factory))
 	}
@@ -21,4 +22,51 @@ impl<'a, Storage, Q: ToOwned> For<'a, Storage, Q> {
 			factory,
 		}
 	}
+
+	/// Implementation detail.
+	#[doc(hidden)]
+	#[allow(clippy::type_complexity, non_snake_case)]
+	pub fn __Asteracea__update_try_by<'b, 'c: 'b, T, Q: 'b>(
+		&'b mut self,
+		items: impl 'c + IntoIterator<Item = T>,
+		selector: impl 'c + FnMut(&mut T) -> Result<&Q, Escalation>,
+	) -> Box<dyn 'b + Iterator<Item = Result<(T, Pin<&mut Storage>), Escalation>>>
+	where
+		T: 'b,
+		K: Borrow<Q>,
+		Q: Eq + ToOwned<Owned = K>,
+	{
+		let factory = &mut self.factory;
+		<Pin<Linotype<K, Storage>> as PinningLinotype>::update_try_by_try_with(
+			&mut self.linotype,
+			items,
+			selector,
+			move |_| factory(),
+		)
+	}
 }
+
+pub struct MixedKey {
+	// variant: MixedKey_,
+}
+
+// #[allow(incorrect_ident_case)]
+// enum MixedKey_ {
+// 	char(char),
+// 	i8(i8),
+// 	i16(i16),
+// 	i32(i32),
+// 	i64(i64),
+// 	i128(i128),
+// 	isize(isize),
+// 	u8(u8),
+// 	u16(u16),
+// 	u32(u32),
+// 	u64(u64),
+// 	u128(u128),
+// 	usize(usize),
+// 	f32(f32),
+// 	f64(f64),
+// 	bool(bool),
+// 	String(String),
+// }

--- a/src/storage/for_.rs
+++ b/src/storage/for_.rs
@@ -5,6 +5,13 @@ use linotype::{Linotype, PinningLinotype};
 use crate::error::Escalation;
 
 /// Storage for [`for`](`For`) expressions.
+///
+/// > BUG:
+/// >
+/// > Instead of storing only Storage, this needs to also store a [`u32`] to set up a [`lignin::Node::Keyed`].
+/// >
+/// > Right now, a plain [`lignin::Node::Multi`] is generated, which means internal component state is affixed properly while external component state is not.
+/// > (The unbinding and binding functionality still runs appropriately, so this doesn't cause extremely severe issues, but it can lead to UX degradation in many cases.)
 pub struct For<'a, Storage, K = MixedKey> {
 	linotype: Pin<Linotype<K, Storage>>,
 	factory: Box<dyn 'a + FnMut() -> Result<Storage, Escalation>>,

--- a/tests/for.rs
+++ b/tests/for.rs
@@ -1,7 +1,25 @@
+// asteracea::component! {
+// 	pub ForImplicit()() -> Sync
+
+// 	for i in [1, 2, 3, 4, 5], !"{}"(i)
+// }
+
 asteracea::component! {
-	pub ForImplicit()() -> Sync
+	pub ForImplicitSelector()() -> Sync
 
 	for i: u8 in 1..=5, !"{}"(i)
+}
+
+asteracea::component! {
+	pub ForImplicitItemType()() -> Sync
+
+	for i keyed i => u8 in 1..=5, !"{}"(i)
+}
+
+asteracea::component! {
+	pub ForKeyTypeOnly()() -> Sync
+
+	for i => u8 in 1..=5, !"{}"(i)
 }
 
 asteracea::component! {
@@ -13,5 +31,5 @@ asteracea::component! {
 // asteracea::component! {
 // 	pub ForUntyped()() -> Sync
 
-// 	for i: u8 keyed i in [1, 2, 3, 4, 5], !"{}"(i)
+// 	for i keyed i in [1, 2, 3, 4, 5], !"{}"(i)
 // }

--- a/tests/for.rs
+++ b/tests/for.rs
@@ -45,3 +45,13 @@ asteracea::component! {
 // 		!"{}"(i)
 // 	}
 // }
+
+asteracea::component! {
+  pub Looped()() -> Sync
+
+  for c: &str in "This is a test.".split(' ') {[
+	  <li
+		!"{:?}"(c)
+	  > "\n"
+  ]}
+}

--- a/tests/for.rs
+++ b/tests/for.rs
@@ -1,0 +1,5 @@
+asteracea::component! {
+	pub For()()
+
+	for i keyed &i in [1, 2, 3, 4, 5], !"{}"(i)
+}

--- a/tests/for.rs
+++ b/tests/for.rs
@@ -1,35 +1,47 @@
 // asteracea::component! {
 // 	pub ForImplicit()() -> Sync
 
-// 	for i in [1, 2, 3, 4, 5], !"{}"(i)
+// 	for i in [1, 2, 3, 4, 5] {
+//  	!"{}"(i)
+// 	}
 // }
 
 asteracea::component! {
 	pub ForImplicitSelector()() -> Sync
 
-	for i: u8 in 1..=5, !"{}"(i)
+	for i: u8 in 1..=5 {
+		!"{}"(i)
+	}
 }
 
 asteracea::component! {
 	pub ForImplicitItemType()() -> Sync
 
-	for i keyed i => u8 in 1..=5, !"{}"(i)
+	for i keyed i => u8 in 1..=5 {
+		!"{}"(i)
+	}
 }
 
 asteracea::component! {
 	pub ForKeyTypeOnly()() -> Sync
 
-	for i => u8 in &[1, 2, 3, 4, 5], !"{}"(i)
+	for i => u8 in &[1, 2, 3, 4, 5] {
+		!"{}"(i)
+	}
 }
 
 asteracea::component! {
 	pub ForExplicit()() -> Sync
 
-	for i: u8 keyed i => u8 in [1, 2, 3, 4, 5], !"{}"(i)
+	for i: u8 keyed i => u8 in [1, 2, 3, 4, 5] {
+		!"{}"(i)
+	}
 }
 
 // asteracea::component! {
 // 	pub ForUntyped()() -> Sync
 
-// 	for i keyed i in [1, 2, 3, 4, 5], !"{}"(i)
+// 	for i keyed i in [1, 2, 3, 4, 5] {
+// 		!"{}"(i)
+// 	}
 // }

--- a/tests/for.rs
+++ b/tests/for.rs
@@ -19,7 +19,7 @@ asteracea::component! {
 asteracea::component! {
 	pub ForKeyTypeOnly()() -> Sync
 
-	for i => u8 in 1..=5, !"{}"(i)
+	for i => u8 in &[1, 2, 3, 4, 5], !"{}"(i)
 }
 
 asteracea::component! {

--- a/tests/for.rs
+++ b/tests/for.rs
@@ -47,11 +47,19 @@ asteracea::component! {
 }
 
 asteracea::component! {
-  pub Looped()() -> Sync
+  pub Split()() -> Sync
 
-  for c: &str in "This is a test.".split(' ') {[
+  for c in "This is a test.".split(' ') {[
 	  <li
 		!"{:?}"(c)
 	  > "\n"
   ]}
+}
+
+asteracea::component! {
+  pub Child()() -> Sync
+
+  for _ in 0..5 {
+	  <*ForImplicit>
+  }
 }

--- a/tests/for.rs
+++ b/tests/for.rs
@@ -1,5 +1,5 @@
 asteracea::component! {
-	pub For()()
+	pub For()() -> Sync
 
-	for i keyed &i in [1, 2, 3, 4, 5], !"{}"(i)
+	for i keyed &i => u8 in [1, 2, 3, 4, 5], !"{}"(i)
 }

--- a/tests/for.rs
+++ b/tests/for.rs
@@ -1,5 +1,17 @@
 asteracea::component! {
-	pub For()() -> Sync
+	pub ForImplicit()() -> Sync
 
-	for i keyed &i => u8 in [1, 2, 3, 4, 5], !"{}"(i)
+	for i: u8 in 1..=5, !"{}"(i)
 }
+
+asteracea::component! {
+	pub ForExplicit()() -> Sync
+
+	for i: u8 keyed i => u8 in [1, 2, 3, 4, 5], !"{}"(i)
+}
+
+// asteracea::component! {
+// 	pub ForUntyped()() -> Sync
+
+// 	for i: u8 keyed i in [1, 2, 3, 4, 5], !"{}"(i)
+// }

--- a/tests/for.rs
+++ b/tests/for.rs
@@ -1,10 +1,10 @@
-// asteracea::component! {
-// 	pub ForImplicit()() -> Sync
+asteracea::component! {
+	pub ForImplicit()() -> Sync
 
-// 	for i in [1, 2, 3, 4, 5] {
-//  	!"{}"(i)
-// 	}
-// }
+	for i in [1, 2, 3, 4, 5i32] {
+	 !"{}"(i)
+	}
+}
 
 asteracea::component! {
 	pub ForImplicitSelector()() -> Sync
@@ -38,13 +38,13 @@ asteracea::component! {
 	}
 }
 
-// asteracea::component! {
-// 	pub ForUntyped()() -> Sync
+asteracea::component! {
+	pub ForUntyped()() -> Sync
 
-// 	for i keyed i in [1, 2, 3, 4, 5] {
-// 		!"{}"(i)
-// 	}
-// }
+	for i keyed i in [1, 2, 3, 4, 5] {
+		!"{}"(i)
+	}
+}
 
 asteracea::component! {
   pub Looped()() -> Sync


### PR DESCRIPTION
This PR adds `for`-loops to Asteracea. I'm tagging it `work: novel` even though I'm sure a solution exists elsewhere because I couldn't find any resource explaining it.

A short example is

```rust
asteracea::component! {
  pub Looping()() -> Sync

  for word in "This is a test.".split(' ') {[
      <li
        !"{:?}"(word)
      > "\n"
  ]}
}
```

which results in

```html
<LI>"This"</LI>
<LI>"is"</LI>
<LI>"a"</LI>
<LI>"test."</LI>
```

. A more explicit example is

```rust
asteracea::component! {
  pub Looping()() -> Sync

  for i: u8 keyed &*i => u8 in 0..255 {
    "."
  }
}
```

which results in 255 text nodes with one full stop each.

Type annotations are optional, but make the program a bit faster, since having at least one avoids some `Box` allocations and dynamic type cast checks.

# Future plans

I can likely add `while`-loops very quickly after this, by reusing the `for`-loop infrastructure with a singleton (as in: a ZST that's `Eq`) dummy key. This isn't ideal, in part because the `for`-loop reconciliation isn't as efficient as it could be, but it has the right semantics and should work well for the time being.