### PR TITLE
Add `*for`

### DIFF
--- a/proc-macro-definitions/src/part.rs
+++ b/proc-macro-definitions/src/part.rs
@@ -1,3 +1,4 @@
+mod asterisk_for;
 mod bind;
 mod box_expression;
 mod bump_format_shorthand;
@@ -15,8 +16,9 @@ mod let_self;
 
 pub use self::let_self::LetSelf;
 use self::{
-	bind::Bind, box_expression::BoxExpression, component::Component, content::Content,
-	defer::Defer, for_::For, html_comment::HtmlComment, html_definition::HtmlDefinition,
+	asterisk_for::AsteriskFor, bind::Bind, box_expression::BoxExpression,
+	component::Component, content::Content, defer::Defer, for_::For, html_comment::HtmlComment,
+	html_definition::HtmlDefinition,
 };
 use crate::{
 	asteracea_ident,
@@ -33,7 +35,7 @@ use syn::{
 	parse::{Parse, ParseStream, Result},
 	spanned::Spanned as _,
 	token::{Brace, Bracket},
-	Attribute, Error, Expr, Generics, Ident, LitStr, Pat, Token, Visibility,
+	Attribute, Error, Expr, Generics, Ident, Label, LitStr, Pat, Token, Visibility,
 };
 use syn_mid::Block;
 use tap::Pipe as _;
@@ -41,6 +43,7 @@ use unquote::unquote;
 
 #[allow(clippy::large_enum_variant, clippy::type_complexity)]
 pub(crate) enum Part<C: Configuration> {
+	AsteriskFor(AsteriskFor<C>),
 	Bind(Bind<C>),
 	Box(BoxExpression<C>),
 	BumpFormat(BumpFormat),
@@ -87,7 +90,8 @@ enum PartKind {
 impl<C: Configuration> Part<C> {
 	fn kind(&self) -> PartKind {
 		match self {
-			Part::Bind(_)
+			Part::AsteriskFor(_)
+			| Part::Bind(_)
 			| Part::Box(_)
 			| Part::BumpFormat(_)
 			| Part::Comment(_)
@@ -177,7 +181,19 @@ impl<C: Configuration> ParseWithContext for Part<C> {
 	type Output = Option<Self>;
 	fn parse_with_context(input: ParseStream<'_>, cx: &mut ParseContext) -> Result<Self::Output> {
 		let lookahead = input.lookahead1();
-		if lookahead.peek(bind::kw::bind) {
+		if lookahead.peek(Token![*]) && {
+			let input = input.fork();
+			input.parse::<Token![*]>().expect("infallible");
+			input.parse::<Option<Label>>().expect("infallible");
+			input
+				.parse::<Option<Token![for]>>()
+				.expect("infallible")
+				.is_some()
+		} {
+			Some(Part::AsteriskFor(AsteriskFor::parse_with_context(
+				input, cx,
+			)?))
+		} else if lookahead.peek(bind::kw::bind) {
 			Some(Part::Bind(Bind::parse_with_context(input, cx)?))
 		} else if lookahead.peek(Token![box]) {
 			Some(Part::Box(BoxExpression::parse_with_context(input, cx)?))
@@ -376,6 +392,7 @@ impl<C: Configuration> Part<C> {
 		let thread_safety = &cx.thread_safety;
 		let prefer_thread_safe = &cx.prefer_thread_safe;
 		let mut part_tokens = match self {
+			Part::AsteriskFor(asterisk_for) => asterisk_for.part_tokens(cx)?,
 			Part::Bind(bind) => bind.part_tokens(cx)?,
 			Part::Box(box_expression) => box_expression.part_tokens(cx)?,
 			Part::BumpFormat(bump_format) => {

--- a/proc-macro-definitions/src/part.rs
+++ b/proc-macro-definitions/src/part.rs
@@ -16,8 +16,8 @@ mod let_self;
 
 pub use self::let_self::LetSelf;
 use self::{
-	asterisk_for::AsteriskFor, bind::Bind, box_expression::BoxExpression,
-	component::Component, content::Content, defer::Defer, for_::For, html_comment::HtmlComment,
+	asterisk_for::AsteriskFor, bind::Bind, box_expression::BoxExpression, component::Component,
+	content::Content, defer::Defer, for_::For, html_comment::HtmlComment,
 	html_definition::HtmlDefinition,
 };
 use crate::{

--- a/proc-macro-definitions/src/part/asterisk_for.rs
+++ b/proc-macro-definitions/src/part/asterisk_for.rs
@@ -1,0 +1,181 @@
+use super::{GenerateContext, Part};
+use crate::{
+	asteracea_ident,
+	part::LetSelf,
+	storage_configuration::{StorageConfiguration, StorageTypeConfiguration},
+	storage_context::{ParseContext, ParseWithContext},
+	workaround_module::Configuration,
+};
+use call2_for_syn::call2_strict;
+use debugless_unwrap::DebuglessUnwrap;
+use proc_macro2::{Span, TokenStream};
+use quote::{quote_spanned, ToTokens};
+use syn::{
+	braced, parse::ParseStream, parse_quote_spanned, spanned::Spanned, token::Brace,
+	visit_mut::VisitMut, Error, Expr, Ident, Label, Pat, Result, Token, Type, TypeReference,
+};
+use tap::Pipe;
+use unquote::unquote;
+
+mod kw {
+	use syn::custom_keyword;
+	custom_keyword!(keyed);
+}
+
+#[allow(dead_code)]
+pub struct AsteriskFor<C: Configuration> {
+	asterisk: Token![*],
+	label: Option<Label>,
+	for_: Token![for],
+	field_name: Ident,
+	type_configuration: StorageTypeConfiguration,
+	pat: Pat,
+	in_: Token![in],
+	iterable: Expr,
+	brace: Brace,
+	content: Box<Part<C>>,
+}
+
+impl<C: Configuration> ParseWithContext for AsteriskFor<C> {
+	type Output = Self;
+
+	fn parse_with_context(input: ParseStream<'_>, cx: &mut ParseContext) -> Result<Self::Output> {
+		let storage_configuration: StorageConfiguration;
+		let for_: Token![for];
+		unquote! {input,
+			#let asterisk
+			#let label
+			#for_
+			#storage_configuration
+			#let pat
+			#let in_
+		};
+
+		let iterable = Expr::parse_without_eager_brace(input)?;
+
+		let visibility = storage_configuration.visibility();
+		let field_name = storage_configuration
+			.field_name()
+			.cloned()
+			.unwrap_or_else(|| cx.storage_context.next_field(for_.span));
+		let type_configuration = storage_configuration.type_configuration();
+		let nested_generics = type_configuration.generics()?;
+		let auto_generics = nested_generics.is_none();
+		let nested_generics = nested_generics.unwrap_or_else(|| cx.storage_generics.clone());
+
+		let mut parse_context = cx.new_nested(
+			cx.storage_context.generated_type_name(&field_name),
+			&nested_generics,
+		);
+
+		let content;
+		let brace = braced!(content in input);
+
+		let content = Box::new(Part::parse_required_with_context(
+			&content,
+			&mut parse_context,
+		)?);
+
+		let type_path =
+			type_configuration.type_path(&cx.storage_context, &field_name, cx.storage_generics)?;
+
+		let item_state = parse_context.storage_context.value(
+			type_configuration.type_is_generated(),
+			&type_path,
+			auto_generics,
+		);
+
+		let asteracea = asteracea_ident(for_.span);
+		let node = quote_spanned!(for_.span=> node);
+
+		let item_state = quote_spanned!(for_.span.resolved_at(Span::mixed_site())=> asterisk_for.push(#item_state));
+		let braced_item_state = quote_spanned!(brace.span=> { #item_state });
+
+		call2_strict(
+			quote_spanned! {for_.span.resolved_at(Span::mixed_site())=>
+				let #visibility self.#field_name: ::core::pin::Pin<::std::boxed::Box::<[#type_path]>> = {
+						let mut asterisk_for = ::std::vec::Vec::<#type_path>::new();
+						#label #for_ #pat #in_ #iterable #braced_item_state
+						asterisk_for.into_boxed_slice().into()
+				};
+			},
+			|input| LetSelf::<C>::parse_with_context(input, cx),
+		)
+		.debugless_unwrap()
+		.expect("for loop storage let self");
+
+		if type_configuration.type_is_generated() {
+			cx.assorted_items.extend(
+				type_configuration.struct_definition(
+					vec![],
+					visibility,
+					type_path
+						.path
+						.segments
+						.last()
+						.expect("`*for`: generated storage type last segment")
+						.ident
+						.clone(),
+					&parse_context.storage_context,
+					cx.storage_generics,
+				)?,
+			)
+		}
+
+		cx.assorted_items.extend(parse_context.assorted_items);
+
+		Ok(Self {
+			asterisk,
+			label,
+			for_,
+			field_name,
+			type_configuration,
+			pat,
+			in_,
+			iterable,
+			brace,
+			content,
+		})
+	}
+}
+
+impl<C: Configuration> AsteriskFor<C> {
+	pub fn part_tokens(&self, cx: &GenerateContext) -> Result<TokenStream> {
+		let asteracea = asteracea_ident(self.for_.span);
+		let bump = Ident::new("bump", self.for_.span);
+
+		let Self {
+			label,
+			asterisk,
+			for_,
+			type_configuration,
+			field_name,
+			pat,
+			in_,
+			iterable,
+			brace,
+			content,
+		} = self;
+
+		let for_span_mixed_site = for_.span.resolved_at(Span::mixed_site());
+
+		let content = content.part_tokens(cx)?;
+		let content = quote_spanned! {for_span_mixed_site=>
+			let #field_name = unsafe { ::core::pin::Pin::new_unchecked(#field_name) };
+			let this = #field_name;
+			asterisk_for_items.push(#content)
+		};
+		let content = quote_spanned!(brace.span=> {
+			#content
+		});
+
+		quote_spanned!(for_span_mixed_site=> {
+			let asterisk_for = &this.#field_name;
+			let asterisk_for = &**asterisk_for;
+			let mut asterisk_for_items = ::#asteracea::bumpalo::vec![in #bump];
+			#label #for_ #field_name in asterisk_for.iter() #content
+			::#asteracea::lignin::Node::Multi(asterisk_for_items.into_bump_slice())
+		})
+		.pipe(Ok)
+	}
+}

--- a/proc-macro-definitions/src/part/asterisk_for.rs
+++ b/proc-macro-definitions/src/part/asterisk_for.rs
@@ -9,11 +9,8 @@ use crate::{
 use call2_for_syn::call2_strict;
 use debugless_unwrap::DebuglessUnwrap;
 use proc_macro2::{Span, TokenStream};
-use quote::{quote_spanned, ToTokens};
-use syn::{
-	braced, parse::ParseStream, parse_quote_spanned, spanned::Spanned, token::Brace,
-	visit_mut::VisitMut, Error, Expr, Ident, Label, Pat, Result, Token, Type, TypeReference,
-};
+use quote::quote_spanned;
+use syn::{braced, parse::ParseStream, token::Brace, Expr, Ident, Label, Pat, Result, Token};
 use tap::Pipe;
 use unquote::unquote;
 
@@ -85,9 +82,6 @@ impl<C: Configuration> ParseWithContext for AsteriskFor<C> {
 			auto_generics,
 		);
 
-		let asteracea = asteracea_ident(for_.span);
-		let node = quote_spanned!(for_.span=> node);
-
 		let item_state = quote_spanned!(for_.span.resolved_at(Span::mixed_site())=> asterisk_for.push(#item_state));
 		let braced_item_state = quote_spanned!(brace.span=> { #item_state });
 
@@ -146,13 +140,13 @@ impl<C: Configuration> AsteriskFor<C> {
 
 		let Self {
 			label,
-			asterisk,
+			asterisk: _,
 			for_,
-			type_configuration,
+			type_configuration: _,
 			field_name,
-			pat,
+			pat: _,
 			in_,
-			iterable,
+			iterable: _,
 			brace,
 			content,
 		} = self;
@@ -173,7 +167,7 @@ impl<C: Configuration> AsteriskFor<C> {
 			let asterisk_for = &this.#field_name;
 			let asterisk_for = &**asterisk_for;
 			let mut asterisk_for_items = ::#asteracea::bumpalo::vec![in #bump];
-			#label #for_ #field_name in asterisk_for.iter() #content
+			#label #for_ #field_name #in_ asterisk_for.iter() #content
 			::#asteracea::lignin::Node::Multi(asterisk_for_items.into_bump_slice())
 		})
 		.pipe(Ok)

--- a/proc-macro-definitions/src/part/component.rs
+++ b/proc-macro-definitions/src/part/component.rs
@@ -101,12 +101,12 @@ impl<C: Configuration> ParseWithContext for Component<C> {
 			};
 
 			let mut new_params: Vec<Parameter<Token![*]>> = vec![];
-			while input.peek(Token![*]) {
+			while input.peek(Token![*]) && input.peek2(Ident) {
 				new_params.push(input.parse()?)
 			}
 
 			let mut render_params: Vec<Parameter<Token![.]>> = vec![];
-			while input.peek(Token![.]) && !input.peek(Token![..]) {
+			while input.peek(Token![.]) && input.peek2(Ident) {
 				render_params.push(input.parse()?)
 			}
 

--- a/src/components/router.rs
+++ b/src/components/router.rs
@@ -1,8 +1,7 @@
 #![allow(warnings)] //FIXME
 
 use crate::{
-	error::Escalation,
-	error::Result,
+	error::{Escalation, Result},
 	include::render_callback::RenderOnce,
 	__::{tracing::debug_span, Built},
 };

--- a/tests/asterisk_for.rs
+++ b/tests/asterisk_for.rs
@@ -1,0 +1,9 @@
+#![allow(clippy::reversed_empty_ranges)]
+
+asteracea::component! {
+	Empty()()
+
+	*for _ in 0..0 {
+		[]
+	}
+}

--- a/tests/asterisk_for.rs
+++ b/tests/asterisk_for.rs
@@ -7,3 +7,29 @@ asteracea::component! {
 		[]
 	}
 }
+
+asteracea::component! {
+	WithinHtml()()
+
+	<div
+		*for _ in 0..0 {
+			[]
+		}
+	>
+}
+
+asteracea::component! {
+	Container()(..)
+
+	..
+}
+
+asteracea::component! {
+	AsContent()()
+
+	<*Container
+		*for _ in 0..0 {
+			[]
+		}
+	>
+}


### PR DESCRIPTION
This adds `*for`-loops, that is constructor-scoped `for` loops like the following:

```rust
asteracea::component! {
    Loopy()()

    *for _ in 0..100 {
        "Further content goes here."
    }
}
```

This loops are normal Rust `for` loops that run once in the constructor.
They instantiate storage for their body as necessary, and then when rendering, they loop over this storage rather than the original iterator.